### PR TITLE
Drop support for Qt5 to fix cookie persistency in Qt6

### DIFF
--- a/openfortivpn-webview-qt/README.md
+++ b/openfortivpn-webview-qt/README.md
@@ -9,7 +9,7 @@ stdout and exit.
 ## How to build
 
 The project requires the Qt framework to be installed and it has
-been tested with Qt 5.12.2.
+been tested with Qt 6.4.2.
 
 To build the application, go to the root of the project and run:
 ```shell

--- a/openfortivpn-webview-qt/mainwindow.cpp
+++ b/openfortivpn-webview-qt/mainwindow.cpp
@@ -17,7 +17,8 @@ MainWindow::MainWindow(const bool keepOpen,
                        const QRegularExpression& urlToWaitForRegex,
                        QWidget *parent) :
     QMainWindow(parent),
-    webEngine(new QWebEngineView(new QWebEngineProfile("vpn", parent), parent)),
+    webEngineProfile(new QWebEngineProfile("vpn", parent)),
+    webEngine(new QWebEngineView(webEngineProfile, parent)),
     urlToWaitForRegex(urlToWaitForRegex),
     keepOpen(keepOpen)
 {
@@ -46,6 +47,7 @@ MainWindow::MainWindow(const bool keepOpen,
 MainWindow::~MainWindow()
 {
     delete webEngine;
+    delete webEngineProfile;
 }
 
 void MainWindow::loadUrl(const QString &url)

--- a/openfortivpn-webview-qt/mainwindow.cpp
+++ b/openfortivpn-webview-qt/mainwindow.cpp
@@ -17,7 +17,7 @@ MainWindow::MainWindow(const bool keepOpen,
                        const QRegularExpression& urlToWaitForRegex,
                        QWidget *parent) :
     QMainWindow(parent),
-    webEngine(new QWebEngineView(parent)),
+    webEngine(new QWebEngineView(new QWebEngineProfile("vpn", parent), parent)),
     urlToWaitForRegex(urlToWaitForRegex),
     keepOpen(keepOpen)
 {

--- a/openfortivpn-webview-qt/mainwindow.h
+++ b/openfortivpn-webview-qt/mainwindow.h
@@ -24,6 +24,7 @@ private slots:
     void handleUrlChange(const QUrl &url);
 
 private:
+    QWebEngineProfile *webEngineProfile;
     QWebEngineView *webEngine;
     const QRegularExpression& urlToWaitForRegex;
     const bool keepOpen;


### PR DESCRIPTION
Fixes #14.

As discussed in the issue, Qt6 has been in the wild for more than two years at this point. Whoever needs to build the library, can do so quite easily.