### PR TITLE
Allow User to Trust A Certificate

### DIFF
--- a/openfortivpn-webview-electron/index.js
+++ b/openfortivpn-webview-electron/index.js
@@ -32,7 +32,7 @@ const parser = yargs(hideBin(process.argv))
       type: "string",
   })
   .option('trusted-cert', {
-      describe: '[Danger Zone] Provide the fingerprint to ignore certificate errors.',
+      describe: 'The fingerprint of a certificate to always trust, even if invalid. The details of invalid certificates, fingerprint included, will be dumped in the console.',
       type: "string",
   })
   .help();
@@ -60,9 +60,11 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
     event.preventDefault();
     callback(true);
   } else {
-    console.log('Connection is not secured:');
-    console.log(certificate);
-    console.log('Add argument --trusted-cert=' + certificate.fingerprint + ' to trust the certificate.');
+    console.log('Found an invalid certificate:');
+    console.dir(certificate, { depth: null });
+    console.log();
+    console.log('If you know that this certificate can be trusted, relaunch the application passing the following argument to ignore the error:');
+    console.log(`--trusted-cert='${certificate.fingerprint}'`);
     process.exit(1);
   }
 })

--- a/openfortivpn-webview-electron/index.js
+++ b/openfortivpn-webview-electron/index.js
@@ -1,6 +1,9 @@
 const { app, BrowserWindow, session, Menu } = require('electron');
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')
+const { Console } = require('console');
+
+const errorConsole = new Console(process.stderr);
 
 const defaultUrlRegex = '/sslvpn/portal\\.html';
 const cookieName = 'SVPNCOOKIE';
@@ -60,11 +63,11 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
     event.preventDefault();
     callback(true);
   } else {
-    console.log('Found an invalid certificate:');
-    console.dir(certificate, { depth: null });
-    console.log();
-    console.log('If you know that this certificate can be trusted, relaunch the application passing the following argument to ignore the error:');
-    console.log(`--trusted-cert='${certificate.fingerprint}'`);
+    errorConsole.error('Found an invalid certificate:');
+    errorConsole.dir(certificate, { depth: null });
+    errorConsole.error();
+    errorConsole.error('If you know that this certificate can be trusted, relaunch the application passing the following argument to ignore the error:');
+    errorConsole.error(`--trusted-cert='${certificate.fingerprint}'`);
     process.exit(1);
   }
 })
@@ -103,7 +106,7 @@ if (argv['extra-ca-certs']) {
       }
     });
   } catch (e) {
-    console.error(e.message);
+    errorConsole.error(e.message);
     process.exit(1);
   }
 }

--- a/openfortivpn-webview-electron/package-lock.json
+++ b/openfortivpn-webview-electron/package-lock.json
@@ -1904,9 +1904,9 @@
       }
     },
     "node_modules/global-agent/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2726,9 +2726,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4692,9 +4692,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5305,9 +5305,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "semver-compare": {

--- a/openfortivpn-webview-electron/package-lock.json
+++ b/openfortivpn-webview-electron/package-lock.json
@@ -1904,9 +1904,9 @@
       }
     },
     "node_modules/global-agent/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2726,9 +2726,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4692,9 +4692,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5305,9 +5305,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
     "semver-compare": {


### PR DESCRIPTION
In rare cases, the user may be unable to get around the certificate issue with the `--extra-ca-certs` option. This PR offers an argument to trust a (manually confirmed) certificate by offering its fingerprint.