### PR TITLE
Support newer fortigates

### DIFF
--- a/openfortivpn-webview-electron/index.js
+++ b/openfortivpn-webview-electron/index.js
@@ -5,7 +5,7 @@ const { Console } = require('console');
 
 const errorConsole = new Console(process.stderr);
 
-const defaultUrlRegex = '/sslvpn/portal';
+const defaultUrlRegex = '/sslvpn/portal(/|\\.html)';
 const cookieName = 'SVPNCOOKIE';
 
 const parser = yargs(hideBin(process.argv))
@@ -119,7 +119,7 @@ app.whenReady().then(() => {
 
   const tryPrintCookie = () => {
     if (shouldPrintCookie && svpncookie != null) {
-      process.stdout.write(`${svpncookie}\n`);
+      process.stdout.write(`${cookieName}=${svpncookie}\n`);
       if (!argv['keep-open']) {
         process.exit(0);
       }

--- a/openfortivpn-webview-electron/index.js
+++ b/openfortivpn-webview-electron/index.js
@@ -5,7 +5,7 @@ const { Console } = require('console');
 
 const errorConsole = new Console(process.stderr);
 
-const defaultUrlRegex = '/sslvpn/portal\\.html';
+const defaultUrlRegex = '/sslvpn/portal';
 const cookieName = 'SVPNCOOKIE';
 
 const parser = yargs(hideBin(process.argv))
@@ -119,7 +119,7 @@ app.whenReady().then(() => {
 
   const tryPrintCookie = () => {
     if (shouldPrintCookie && svpncookie != null) {
-      process.stdout.write(`${cookieName}=${svpncookie}\n`);
+      process.stdout.write(`${svpncookie}\n`);
       if (!argv['keep-open']) {
         process.exit(0);
       }

--- a/openfortivpn-webview-qt/main.cpp
+++ b/openfortivpn-webview-qt/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
     auto optionRealm = QCommandLineOption("realm", "The authentication realm.", "realm");
     auto optionUrl = QCommandLineOption("url", "The already built SAML URL.\nThis takes precedence over [host:port].", "url");
     auto optionKeepOpen = QCommandLineOption("keep-open", "Do not close the browser automatically.");
-    auto defaultUrlRegex = "/sslvpn/portal";
+    auto defaultUrlRegex = "/sslvpn/portal(/|\\.html)";
     auto urlRegexDescription = QString("A regex to detect the URL that needs to be visited before printing SVPNCOOKIE.\nThe default is \"%1\".").arg(defaultUrlRegex);
     auto optionUrlRegex = QCommandLineOption("url-regex", urlRegexDescription, "url-regex", defaultUrlRegex);
     auto extraCaCertsDescription = QString("Path to a file with extra certificates. The file should consist of one or more trusted certificates in PEM format.");

--- a/openfortivpn-webview-qt/main.cpp
+++ b/openfortivpn-webview-qt/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
     auto optionRealm = QCommandLineOption("realm", "The authentication realm.", "realm");
     auto optionUrl = QCommandLineOption("url", "The already built SAML URL.\nThis takes precedence over [host:port].", "url");
     auto optionKeepOpen = QCommandLineOption("keep-open", "Do not close the browser automatically.");
-    auto defaultUrlRegex = "/sslvpn/portal\\.html";
+    auto defaultUrlRegex = "/sslvpn/portal";
     auto urlRegexDescription = QString("A regex to detect the URL that needs to be visited before printing SVPNCOOKIE.\nThe default is \"%1\".").arg(defaultUrlRegex);
     auto optionUrlRegex = QCommandLineOption("url-regex", urlRegexDescription, "url-regex", defaultUrlRegex);
     auto extraCaCertsDescription = QString("Path to a file with extra certificates. The file should consist of one or more trusted certificates in PEM format.");

--- a/openfortivpn-webview-qt/mainwindow.cpp
+++ b/openfortivpn-webview-qt/mainwindow.cpp
@@ -67,7 +67,7 @@ void MainWindow::loadUrl(const QString &url)
 void MainWindow::onCookieAdded(const QNetworkCookie &cookie)
 {
     if (cookie.name() == "SVPNCOOKIE") {
-        svpncookie = QString(cookie.name()) + "=" + QString(cookie.value());
+        svpncookie = QString(cookie.value());
 
         qCDebug(category) << "SVPNCOOKIE has been received";
 

--- a/openfortivpn-webview-qt/mainwindow.cpp
+++ b/openfortivpn-webview-qt/mainwindow.cpp
@@ -67,7 +67,7 @@ void MainWindow::loadUrl(const QString &url)
 void MainWindow::onCookieAdded(const QNetworkCookie &cookie)
 {
     if (cookie.name() == "SVPNCOOKIE") {
-        svpncookie = QString(cookie.value());
+        svpncookie = QString(cookie.name()) + "=" + QString(cookie.value());
 
         qCDebug(category) << "SVPNCOOKIE has been received";
 


### PR DESCRIPTION
Newer Fortigate SSLVPNs do not have .html in the url, but have `.../sslvpn/portal/` instead. This makes it backwards compatible.